### PR TITLE
use name from theming app in email's subject

### DIFF
--- a/lib/Service/Email.php
+++ b/lib/Service/Email.php
@@ -8,6 +8,7 @@ use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IUser;
 use OCP\Mail\IMailer;
+use OCP\Defaults;
 
 class Email {
 
@@ -20,12 +21,17 @@ class Email {
 	/** @var ILogger */
 	private $logger;
 
+	/** @var Defaults */
+	private $themingDefaults;
+
 	public function __construct(IMailer $mailer,
 								IL10N $l10n,
-								ILogger $logger) {
+								ILogger $logger,
+								Defaults $themingDefaults) {
 		$this->mailer = $mailer;
 		$this->l10n = $l10n;
 		$this->logger = $logger;
+		$this->themingDefaults = $themingDefaults;
 	}
 
 	/**
@@ -36,7 +42,7 @@ class Email {
 		$this->logger->debug('sending email message to ' . $user->getEMailAddress() . ', authentication code: $authenticationCode');
 
 		$template = $this->mailer->createEMailTemplate('twofactor_email.send');
-		$template->setSubject($this->l10n->t('Nextcloud Two-Factor Authentication'));
+		$template->setSubject($this->l10n->t('%s Two-Factor Authentication', [$this->themingDefaults->getName()]));
 		$template->addHeader();
 		$template->addHeading($this->l10n->t('Your account %s is protected by two-factor authentication.', [$user->getDisplayName()]));
 		$template->addBodyText($this->l10n->t('Your code to continue your login is: %s', [$authenticationCode]));


### PR DESCRIPTION
I tried to use name from theming in email's subject instead of hardcoded "Nextcloud". Not sure if it's the right approach but it works on my test setup.