### PR TITLE
Update "maximum version"

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@
 	<repository type="git">https://github.com/rullzer/twofactor_email.git</repository>
 	<dependencies>
 		<php min-version="7.1" max-version="7.4" />
-		<nextcloud min-version="16" max-version="18" />
+		<nextcloud min-version="16" max-version="19" />
 	</dependencies>
 	<two-factor-providers>
 		<provider>OCA\TwoFactorEmail\Provider\Email</provider>


### PR DESCRIPTION
I'm hoping this will let Nextcloud know that NC 19 supports this app so that when people upgrade, nextcloud doesn't _auto disable_ what is potentially the only 2FA method users have implemented.